### PR TITLE
examples: per-tool featured strip, Wikidata keyword chips, DOI

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -217,12 +217,13 @@ note = "Developed by external partners — GRID4EARTH added HEALPix-ellipsoid su
 [extra.featured]
 tag = "SEE IT IN ACTION"
 title = "Featured examples"
-subtitle = "A few real-world applications built on the HEALPix DGGS tools — from Earth-observation data conversion to the sphere-vs-WGS84 comparison that motivates ellipsoidal HEALPix."
+subtitle = "One worked, runnable example per GRID4EARTH tool — each showcasing a different part of the stack, from indexing to resampling to analysis to plotting."
 cta_text = "Explore all examples →"
 cta_url = "/community/"
 
 [[extra.featured.items]]
 name = "earthcare-dggs"
+tool = "healpix-geo"
 keywords = [{term = "Earth observation", qid = "Q1348989"}, {term = "EarthCARE", qid = "Q1277576"}, {term = "aerosol", qid = "Q104541"}]
 type = "Application"
 description = "Convert ESA EarthCARE L2 satellite data (MSI / ATLID / CPR) to HEALPix DGGS-Zarr with healpix-geo and xdggs."
@@ -231,23 +232,36 @@ repo_url = "https://github.com/annefou/earthcare-dggs"
 doi_url = "https://doi.org/10.5281/zenodo.19709327"
 
 [[extra.featured.items]]
-name = "healpix_geo_replication_2026"
-keywords = [{term = "discrete global grid system", qid = "Q117479905"}, {term = "land use", qid = "Q1165944"}, {term = "reproducibility", qid = "Q1425625"}]
+name = "fiesta-scattering-sst-healpix-geo"
+tool = "healpix-resample"
+keywords = [{term = "sea surface temperature", qid = "Q1507383"}, {term = "wavelet", qid = "Q831390"}, {term = "ocean", qid = "Q9430"}]
 type = "Benchmark"
-description = "Why the reference surface matters: HEALPix land-use benchmarks on the sphere vs the WGS84 ellipsoid, computed with healpix-geo."
-url = "https://annefou.github.io/healpix_geo_replication_2026/"
-repo_url = "https://github.com/annefou/healpix_geo_replication_2026"
-doi_url = "https://doi.org/10.5281/zenodo.19488374"
+outcome_url = "https://w3id.org/sciencelive/np/RAs--Uf0wMFAWeTv54c4P37QYNp70c8nxUY9M6HgOfg4c"
+description = "Does the WGS84 ellipsoid matter for SST gap-filling? A sphere-vs-ellipsoid HEALPix comparison for scattering-transform reconstruction of Copernicus Marine SST, via healpix-resample / healpix-geo."
+url = "https://annefou.github.io/fiesta-scattering-sst-healpix-geo/"
+repo_url = "https://github.com/annefou/fiesta-scattering-sst-healpix-geo"
+doi_url = "https://doi.org/10.5281/zenodo.19693573"
 
 [[extra.featured.items]]
-name = "white-shark-geolocation-light"
-keywords = [{term = "great white shark", qid = "Q129026"}, {term = "biologging", qid = "Q131143720"}, {term = "sea surface temperature", qid = "Q1507383"}]
+name = "healpix-analyse-s2-powerspectrum"
+tool = "healpix-analyse"
+keywords = [{term = "Sentinel-2", qid = "Q4302480"}, {term = "power spectrum", qid = "Q1331626"}, {term = "Earth observation", qid = "Q1348989"}]
+type = "Application"
+description = "The angular power spectrum of a Sentinel-2 scene on equal-area HEALPix — put EO data on the WGS84 grid with healpix-geo, analyse it with the differentiable (PyTorch) healpix-analyse."
+url = "https://annefou.github.io/healpix-analyse-s2-powerspectrum/"
+repo_url = "https://github.com/annefou/healpix-analyse-s2-powerspectrum"
+doi_url = "https://doi.org/10.5281/zenodo.21000097"
+
+[[extra.featured.items]]
+name = "weatherxbiodiversity-projection"
+tool = "healpix-plot"
+keywords = [{term = "bumblebee", qid = "Q25407"}, {term = "climate change", qid = "Q125928"}, {term = "biodiversity", qid = "Q47041"}]
 type = "Replication"
-outcome_url = "https://w3id.org/sciencelive/np/RAlwDA35wFcmV-ZYzOUB_E3SrqPMIlIxWftoiPFbzN-7I"
-description = "Open marine-animal geolocation (pangeo-fish HMM) on a HEALPix-NESTED grid with healpix-geo + xdggs."
-url = "https://annefou.github.io/white-shark-geolocation-light/"
-repo_url = "https://github.com/annefou/white-shark-geolocation-light"
-doi_url = "https://doi.org/10.5281/zenodo.20585041"
+outcome_url = "https://w3id.org/sciencelive/np/RAPZMgcYbScSAXnrnSySQwZzgSA_rn-xodlMxNlwwQYY8"
+description = "Projecting Iberian bumblebee extirpation risk under Destination Earth Climate DT (SSP3-7.0) on equal-area HEALPix (depth 6, WGS84), plotted with healpix-plot."
+url = "https://annefou.github.io/weatherxbiodiversity-projection/"
+repo_url = "https://github.com/annefou/weatherxbiodiversity-projection"
+doi_url = "https://doi.org/10.5281/zenodo.20113777"
 
 # ── Outreach & dissemination ───────────────────────────────────────────────────
 # Conference talks / demonstrations of GRID4EARTH (not example repos themselves).
@@ -349,16 +363,6 @@ repo_url = "https://github.com/annefou/weatherxbiodiversity-projection"
 doi_url = "https://doi.org/10.5281/zenodo.20113777"
 
 [[extra.community.examples]]
-name = "dggs-biodiversity-bias"
-keywords = [{term = "biodiversity", qid = "Q47041"}, {term = "GBIF", qid = "Q1531570"}, {term = "discrete global grid system", qid = "Q117479905"}]
-note = "Built on healpy (spherical HEALPix), not the WGS84-ellipsoidal healpix-geo."
-type = "Application"
-description = "Why equal-area DGGS cells matter for climate-driven biodiversity science — reproducible notebooks integrating GBIF occurrences with Copernicus / Destination Earth on HEALPix."
-url = "https://annefou.github.io/dggs-biodiversity-bias/"
-repo_url = "https://github.com/annefou/dggs-biodiversity-bias"
-doi_url = "https://doi.org/10.5281/zenodo.19848749"
-
-[[extra.community.examples]]
 name = "healpix_geo_replication_2026"
 keywords = [{term = "discrete global grid system", qid = "Q117479905"}, {term = "land use", qid = "Q1165944"}, {term = "reproducibility", qid = "Q1425625"}]
 type = "Benchmark"
@@ -388,14 +392,14 @@ repo_url = "https://github.com/annefou/fiesta-scattering-sst-healpix-geo"
 doi_url = "https://doi.org/10.5281/zenodo.19693573"
 
 [[extra.community.examples]]
-name = "spherical-ml-biodiversity"
-keywords = [{term = "machine learning", qid = "Q2539"}, {term = "marine heatwave", qid = "Q56321065"}, {term = "biodiversity", qid = "Q47041"}]
-note = "Built on healpy (spherical HEALPix), not the WGS84-ellipsoidal healpix-geo."
+name = "healpix-analyse-s2-powerspectrum"
+tool = "healpix-analyse"
+keywords = [{term = "Sentinel-2", qid = "Q4302480"}, {term = "power spectrum", qid = "Q1331626"}, {term = "Earth observation", qid = "Q1348989"}]
 type = "Application"
-description = "What spherical machine learning is and why it matters for global Earth science — why flat CNNs fail on the sphere, why HEALPix, and a worked replication on Copernicus marine heatwaves tied to biodiversity outcomes."
-url = "https://annefou.github.io/spherical-ml-biodiversity/"
-repo_url = "https://github.com/annefou/spherical-ml-biodiversity"
-doi_url = "https://doi.org/10.5281/zenodo.20082933"
+description = "The angular power spectrum of a Sentinel-2 scene on equal-area HEALPix — put EO data on the WGS84 grid with healpix-geo, analyse it with the differentiable (PyTorch) healpix-analyse."
+url = "https://annefou.github.io/healpix-analyse-s2-powerspectrum/"
+repo_url = "https://github.com/annefou/healpix-analyse-s2-powerspectrum"
+doi_url = "https://doi.org/10.5281/zenodo.21000097"
 
 # ── Footer ─────────────────────────────────────────────────────────────────────
 [extra.footer]

--- a/templates/macros/cards.html
+++ b/templates/macros/cards.html
@@ -14,6 +14,7 @@
 {% macro resource_card(item) %}
 <div class="tool-card">
   {% if item.type %}<span class="card-type" style="display:inline-block; font-size:0.68rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding:0.15rem 0.55rem; border-radius:999px; background:rgba(0,114,178,0.12); color:#0072B2; margin-bottom:0.7rem;">{{ item.type }}</span>{% endif %}
+  {% if item.tool %}<span class="card-tool" title="Showcases the {{ item.tool }} tool" style="display:inline-block; font-size:0.68rem; font-weight:700; padding:0.15rem 0.55rem; border-radius:999px; background:rgba(0,158,115,0.14); color:#067a59; margin:0 0 0.7rem 0.35rem;"><i class="fa-solid fa-gear"></i> {{ item.tool }}</span>{% endif %}
   <h3>{{ item.name }}</h3>
   <p class="tool-tagline">{{ item.description }}</p>
   {% if item.note %}<p class="tool-note"><i class="fa-solid fa-circle-info"></i> {{ item.note }}</p>{% endif %}


### PR DESCRIPTION
Lands the example-curation work stranded when #11 squash-merged at its first commit (the same early-merge pattern as #9 → #10). `main` currently has only the nav anchor; this brings the rest.

**Featured** — restructured to one runnable example per GRID4EARTH tool, each with a green tool badge:
- `healpix-geo` → earthcare-dggs
- `healpix-resample` → fiesta-scattering-sst-healpix-geo
- `healpix-analyse` → **healpix-analyse-s2-powerspectrum** (new, released v0.1.0 → Zenodo `10.5281/zenodo.21000097`)
- `healpix-plot` → weatherxbiodiversity-projection

**Catalogue**
- Added the new healpix-analyse-s2-powerspectrum example (with DOI).
- Added Wikidata-verified topic keyword chips to every card; flagged the non-healpix-geo ones.
- Removed the two healpy-only cards (dggs-biodiversity-bias, spherical-ml-biodiversity).

Validated locally with zola 0.17.2 (build green; DOI links and tool badges present in built HTML).