### PR TITLE
examples: add FORRT Outcome link to the healpix-analyse-s2 cards

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -251,6 +251,7 @@ description = "The angular power spectrum of a Sentinel-2 scene on equal-area HE
 url = "https://annefou.github.io/healpix-analyse-s2-powerspectrum/"
 repo_url = "https://github.com/annefou/healpix-analyse-s2-powerspectrum"
 doi_url = "https://doi.org/10.5281/zenodo.21000097"
+outcome_url = "https://w3id.org/sciencelive/np/RAW7XIpK-5SmVOoRoVPl-w_xjr9cqgM8xRRIKQ575RVXs"
 
 [[extra.featured.items]]
 name = "weatherxbiodiversity-projection"
@@ -400,6 +401,7 @@ description = "The angular power spectrum of a Sentinel-2 scene on equal-area HE
 url = "https://annefou.github.io/healpix-analyse-s2-powerspectrum/"
 repo_url = "https://github.com/annefou/healpix-analyse-s2-powerspectrum"
 doi_url = "https://doi.org/10.5281/zenodo.21000097"
+outcome_url = "https://w3id.org/sciencelive/np/RAW7XIpK-5SmVOoRoVPl-w_xjr9cqgM8xRRIKQ575RVXs"
 
 # ── Footer ─────────────────────────────────────────────────────────────────────
 [extra.footer]


### PR DESCRIPTION
The FORRT replication chain for [`healpix-analyse-s2-powerspectrum`](https://github.com/annefou/healpix-analyse-s2-powerspectrum) is now published on Science Live. This adds its **Outcome** nanopub as `outcome_url` on both the featured and community cards, so the card links to the verified-knowledge record like the other examples.

- Outcome URI: `https://w3id.org/sciencelive/np/RAW7XIpK-5SmVOoRoVPl-w_xjr9cqgM8xRRIKQ575RVXs` (step 05 of the published chain).
- Kept `type = "Application"`: the chain is question-rooted (a methods demonstration), not a replication of a third party's study — and the sibling `Benchmark` card already shows outcome links pair fine with non-"Replication" types.

Validated with zola 0.17.2 (build green; the outcome link is present in both `index.html` and `community/index.html`).